### PR TITLE
log to a csv file, fix the command for sonoma

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ rm cron-new
 
 ## Viewing Usage Data
 
-Once installed, the energy tracker will log all energy consumption to the file `~/Library/Caches/energy-tracker/energy-log.txt`.
+Once installed, the energy tracker will log all energy consumption to the file `~/.cache/energy-tracker/energy-log.txt`.
 
 This file will look something like this:
 
 ```text
-timestamp=2022-01-20T05:48:00Z wattage=9.13724327 wattHours=.15228738783333333333 uuid=9D1166AE-BAC5-52CB-976C-B86196AC744D
-timestamp=2022-01-20T05:49:00Z wattage=7.54702139 wattHours=.12578368983333333333 uuid=9D1166AE-BAC5-52CB-976C-B86196AC744D
-timestamp=2022-01-20T05:50:01Z wattage=7.04053497 wattHours=.11734224950000000000 uuid=9D1166AE-BAC5-52CB-976C-B86196AC744D
-timestamp=2022-01-20T05:51:00Z wattage=7.21910381 wattHours=.12031839683333333333 uuid=9D1166AE-BAC5-52CB-976C-B86196AC744D
+timestamp,wattage,wattHours,uuid
+2024-04-13T12:02:35Z,8.46427726,.14107128766666666666,8D154220-45E6-5C0D-9753-3DAF9F757909
+2024-04-13T12:18:01Z,10.1954079,.16992346500000000000,8D154220-45E6-5C0D-9753-3DAF9F757909
+2024-04-13T12:19:01Z,9.24522876,.15408714600000000000,8D154220-45E6-5C0D-9753-3DAF9F757909
+2024-04-13T12:20:00Z,9.16311264,.15271854400000000000,8D154220-45E6-5C0D-9753-3DAF9F757909
 ```
 
 Each line contains a timestamp, the amount of wattage being used at the time of sampling, the amount of watt-hours being used, and the uuid of the Mac.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ To start, copy the energy tracking script into the correct folder:
 sudo cp log-power-usage.sh /usr/local/bin/log-power-usage.sh
 ```
 
+### Cron
 Next, install the cron script which will run the energy tracker once per minute:
 
 ```bash
@@ -22,6 +23,21 @@ crontab cron-new
 rm cron-new
 ```
 
+### plist
+Alternatively, you can install the plist file which will run the energy tracker every 10 seconds.
+Copy the plist file to the LaunchAgents folder:
+
+```bash
+cp com.raoulg.log-power-usage.plist ~/Library/LaunchAgents/
+```
+
+Then load the plist file:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.raoulg.log-power-usage.plist
+```
+
+In settings > general > Login Items you should see the log-power-usage.sh script under 'allow in background'. This means the script is running.
 
 ## Viewing Usage Data
 

--- a/com.raoulg.log-power-usage.plist
+++ b/com.raoulg.log-power-usage.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.raoulg.log-power-usage</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/log-power-usage.sh</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>30</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>

--- a/log-power-usage.sh
+++ b/log-power-usage.sh
@@ -16,7 +16,7 @@
 # Created: 2022-01-19
 
 # GLOBALS
-TRACKER_DIR=~/Library/Caches/energy-tracker 
+TRACKER_DIR=~/.cache/energy-tracker
 TRACKER_FILE=energy-log.txt
 IOREG=/usr/sbin/ioreg
 

--- a/log-power-usage.sh
+++ b/log-power-usage.sh
@@ -21,7 +21,10 @@ TRACKER_FILE=energy-log.txt
 IOREG=/usr/sbin/ioreg
 
 # PREREQUISITES
-mkdir -p ~/Library/Caches/energy-tracker
+if [[ ! -f "$TRACKER_DIR/$TRACKER_FILE" ]]; then
+  mkdir -p "$TRACKER_DIR"
+  echo "timestamp,wattage,wattHours,uuid" > "$TRACKER_DIR/$TRACKER_FILE"
+fi
 
 if ! command -v $IOREG &> /dev/null
 then

--- a/log-power-usage.sh
+++ b/log-power-usage.sh
@@ -45,4 +45,5 @@ fi
 uuid=`$IOREG -d2 -c IOPlatformExpertDevice | awk -F\" '/IOPlatformUUID/{print $(NF-1)}'`
 timestamp=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
-echo "timestamp=$timestamp wattage=$wattage wattHours=$wattHours uuid=$uuid" >> "$TRACKER_DIR/$TRACKER_FILE"
+# echo "timestamp=$timestamp wattage=$wattage wattHours=$wattHours uuid=$uuid" >> "$TRACKER_DIR/$TRACKER_FILE"
+echo "$timestamp,$wattage,$wattHours,$uuid" >> "$TRACKER_DIR/$TRACKER_FILE"

--- a/log-power-usage.sh
+++ b/log-power-usage.sh
@@ -33,7 +33,8 @@ then
 fi
 
 # Compute energy usage
-wattage=`$IOREG -rw0 -c AppleSmartBattery | grep BatteryData | grep -o '"AdapterPower"=[0-9]*' | cut -c 16- | xargs -I %  lldb --batch -o "print/f %" | grep -o '$0 = [0-9.]*' | cut -c 6-`
+# wattage=`$IOREG -rw0 -c AppleSmartBattery | grep BatteryData | grep -o '"AdapterPower"=[0-9]*' | cut -c 16- | xargs -I %  lldb --batch -o "print/f %" | grep -o '$0 = [0-9.]*' | cut -c 6-`
+wattage=`$IOREG -rw0 -c AppleSmartBattery | grep BatteryData | grep -o '"AdapterPower"=[0-9]*' | cut -c 16- | xargs -I %  lldb --batch -o "    print/f %" | tail -n 1 | awk '{print $2}'`
 wattHours=$(bc -l <<<"${wattage}/60")
 
 # Only proceed if the amount of wattage being used is > 0


### PR DESCRIPTION
The current command did not store the output.
I used tail -n 1 to get the number from lldb, and awk to remove the `(int)`.

Additionally, I check if the file exists, if not, I create a first line with the column names.
This way it is easier to read the file with the most common libraries
